### PR TITLE
add parallel measurements, pingpong entry point, report RTT durations instead of timestamps 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ dependencies = [
     "click"
 ]
 version = "0.1"
+
+[project.scripts]
+pingpong = "pingpong.__main__:pingpong"

--- a/src/pingpong/__init__.py
+++ b/src/pingpong/__init__.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import sys
@@ -7,7 +6,6 @@ import tempfile
 import time
 import concurrent.futures
 from pathlib import Path
-from threading import Thread
 
 from deltachat_rpc_client import DeltaChat, EventType, Rpc
 

--- a/src/pingpong/__init__.py
+++ b/src/pingpong/__init__.py
@@ -110,9 +110,9 @@ class PongerProcess:
 def run(api, proc, num_pings):
     elapsed = Elapsed()
 
-    print(f"make accounts {elapsed} started")
+    print(f"making {proc} accounts", file=sys.stderr)
     accounts = make_accounts(proc * 2, lambda: create_account(api))
-    print(f"make accounts finished, took {elapsed}")
+    print(f"{proc} accounts finished, took {elapsed}", file=sys.stderr)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=proc * 2) as executor:
         for i in range(proc):

--- a/src/pingpong/__init__.py
+++ b/src/pingpong/__init__.py
@@ -32,7 +32,6 @@ def make_accounts(num, account_maker):
 
 def create_account(api):
     account = api.add_account()
-
     account.set_config("bot", "1")
     account.set_config("bcc_self", "0")
     account.set_config("mvbox_move", "0")
@@ -51,7 +50,11 @@ def create_account(api):
     creds = get_temp_credentials()
     account.set_config("addr", creds["email"])
     account.set_config("mail_pw", creds["password"])
+    domain = creds["email"].split("@")[1]
+    account.set_config("mail_server", domain)
+    account.set_config("send_server", domain)
     account.configure()
+    # print(f"account configured {creds['email']}", file=sys.stderr)
     account.start_io()
     return account
 
@@ -110,9 +113,12 @@ class PongerProcess:
 def run(api, proc, num_pings):
     elapsed = Elapsed()
 
-    print(f"making {proc} accounts", file=sys.stderr)
+    print(f"making {proc} ping-accounts and {proc} pong-accounts", file=sys.stderr)
     accounts = make_accounts(proc * 2, lambda: create_account(api))
-    print(f"{proc} accounts finished, took {elapsed}", file=sys.stderr)
+    speed = proc * 2 / elapsed()
+    print(
+        f"finished, took {elapsed} ({speed:0.02f} accounts per second)", file=sys.stderr
+    )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=proc * 2) as executor:
         for i in range(proc):

--- a/src/pingpong/__main__.py
+++ b/src/pingpong/__main__.py
@@ -3,12 +3,17 @@ from . import run_bot
 
 
 @click.command()
-@click.option("--count", default=100, help="Maximum number of messages to send.")
 @click.option(
-    "--window", default=1, help="Number of messages to send at the same time."
+    "--num-pings", "-n", default=10, help="Number of pings to send in each ping-process"
 )
-def pingpong(window, count):
-    run_bot(window, count)
+@click.option(
+    "--proc",
+    "-p",
+    default=1,
+    help="Number of ping/pong processes to run concurrently. ",
+)
+def pingpong(proc, num_pings):
+    run_bot(proc, num_pings)
 
 
 if __name__ == "__main__":

--- a/src/pingpong/__main__.py
+++ b/src/pingpong/__main__.py
@@ -3,12 +3,12 @@ from . import run_bot
 
 
 @click.command()
-@click.option("--limit", default=100, help="Maximum number of messages to send.")
+@click.option("--count", default=100, help="Maximum number of messages to send.")
 @click.option(
     "--window", default=1, help="Number of messages to send at the same time."
 )
-def pingpong(window, limit):
-    run_bot(window, limit)
+def pingpong(window, count):
+    run_bot(window, count)
 
 
 if __name__ == "__main__":

--- a/src/pingpong/__main__.py
+++ b/src/pingpong/__main__.py
@@ -10,10 +10,16 @@ from . import run_bot
     "--proc",
     "-p",
     default=1,
-    help="Number of ping/pong processes to run concurrently. ",
+    help="Number of ping/pong processes to run concurrently (default 1). ",
 )
-def pingpong(proc, num_pings):
-    run_bot(proc, num_pings)
+@click.option(
+    "--window",
+    "-w",
+    default=1,
+    help="Num of simultanous pings per process (default 1)",
+)
+def pingpong(proc, num_pings, window):
+    run_bot(proc, num_pings, window)
 
 
 if __name__ == "__main__":

--- a/stat.pl
+++ b/stat.pl
@@ -11,7 +11,7 @@ while (my $line = <$data>) {
   chomp $line;
   my @fields = split "," , $line;
   if (defined $prev) {
-     push(@values, $fields[1] - $prev)
+     push(@values, $fields[1])
   }
   $prev = $fields[1]
 }


### PR DESCRIPTION
- adds `pingpong` as entry point/CLI 
- `--proc` or `-p` set number of parallel processes 
- `--num-pings` or `-n` sets number of pings each process does 
- the output now shows RTT duration instread of absolute timestamp 

the results of "pingpong -p 25 -n 10", processed by "stats.pl" are: 

```
(py3) hpk@beta:~/p/delta/pingpong (hpk/measure-more)$ ./stat.pl output-c3-p25-n10.csv 
min:    1.6768996715545654
p05:    1.776766300201416
median: 1.9849979877471924
p95:    5.82381534576416
max:    8.827854633331299
(py3) hpk@beta:~/p/delta/pingpong (hpk/measure-more)$ ./stat.pl output-nine-p25-n10.csv 
min:    0.44806742668151855
p05:    0.5222830772399902
median: 1.3506550788879395
p95:    2.015578508377075
max:    7.284121751785278
```